### PR TITLE
Ported instance Example to Bevy 0.9.1

### DIFF
--- a/src/instancing/material/plugin.rs
+++ b/src/instancing/material/plugin.rs
@@ -608,7 +608,7 @@ impl<M: MaterialInstanced> EntityRenderCommand for DrawBatchedInstances<M> {
             for (i, indirect) in batch.indirect_buffer.indirects.iter().enumerate() {
                 if render_device
                     .features()
-                    .contains(wgpu::Features::INDIRECT_FIRST_INSTANCE)
+                    .contains(bevy::render::render_resource::WgpuFeatures::INDIRECT_FIRST_INSTANCE)
                 {
                     match indirect {
                         IndirectDraw::Indexed(_) => {

--- a/src/instancing/material/systems/prepare_batched_instances.rs
+++ b/src/instancing/material/systems/prepare_batched_instances.rs
@@ -12,7 +12,8 @@ use bevy::{
         Extract,
     },
 };
-use wgpu::{BindGroupDescriptor, BindGroupEntry, BufferBinding, BufferUsages};
+// use wgpu::{BindGroupDescriptor, BindGroupEntry, BufferBinding, BufferUsages};
+use bevy::render::render_resource::{BindGroupDescriptor, BindGroupEntry, BufferBinding, BufferUsages};
 
 use crate::instancing::{
     indirect::{DrawCall, DrawOffsets, IndirectDraw},
@@ -325,7 +326,7 @@ pub fn system<M: MaterialInstanced>(
                                 .bind_group_layout,
                             entries: &[BindGroupEntry {
                                 binding: 0,
-                                resource: wgpu::BindingResource::Buffer(BufferBinding {
+                                resource: bevy::render::render_resource::BindingResource::Buffer(BufferBinding {
                                     buffer: buffer.buffer().unwrap(),
                                     offset: 0,
                                     size: Some(

--- a/src/instancing/material/systems/prepare_mesh_batches.rs
+++ b/src/instancing/material/systems/prepare_mesh_batches.rs
@@ -12,7 +12,8 @@ use bevy::{
         renderer::{RenderDevice, RenderQueue},
     },
 };
-use wgpu::BufferUsages;
+// use wgpu::BufferUsages;
+use bevy::render::render_resource::BufferUsages;
 
 use crate::instancing::material::plugin::{GpuIndirectData, InstancedMeshKey, RenderMeshes};
 


### PR DESCRIPTION
replaced wgpu resources for bevy::render equivalents for /materials